### PR TITLE
Fixes donation autofire by using activist's email

### DIFF
--- a/app/mailers/donations_mailer.rb
+++ b/app/mailers/donations_mailer.rb
@@ -12,7 +12,7 @@ class DonationsMailer < ApplicationMailer
     from_address = sender ? "#{sender} <#{email_address}>" : email_address
 
     mail(
-      to: donation.customer['email'],
+      to: donation.email,
       subject: subject,
       from: from_address
     )

--- a/app/services/subscription_service.rb
+++ b/app/services/subscription_service.rb
@@ -62,6 +62,8 @@ class SubscriptionService < DonationService
     ActiveRecord::Base.transaction do
       subscription = self.new_subscription(donation)
       subscription.customer = self.customer_params(donation, address)
+      donation.email = donation.activist.email
+      donation.save
 
       begin
         subscription.create

--- a/spec/mailers/donations_mailer_spec.rb
+++ b/spec/mailers/donations_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DonationsMailer, type: :mailer do
         settings: {email_text: "Thank you for doing this!"}
       )
 
-      @donation = stub_model Donation, widget: @widget, customer: { email: 'donor@foobar.com' }
+      @donation = stub_model Donation, widget: @widget, email: 'donor@foobar.com'
     end
 
     it "should deliver a message from mobilization's creator" do
@@ -29,7 +29,7 @@ RSpec.describe DonationsMailer, type: :mailer do
 
     it "should deliver a message to donor" do
       email = DonationsMailer.thank_you_email(@donation).deliver_now
-      expect(email.to).to eq([@donation.customer['email']])
+      expect(email.to).to eq([@donation.email])
     end
 
     it "should send an email with the properly subject" do


### PR DESCRIPTION
Fixes autofire when donations didn't have an email address associated. All donations that are subscriptions were already updated with the correct email addresses.