### PR TITLE
Removes subscription detection method

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -33,10 +33,6 @@ class Donation < ActiveRecord::Base
     end
   end
 
-  def subscription?
-    self.subscription_id.present?
-  end
-
   def donor
     self.activist.name if self.activist
   end


### PR DESCRIPTION
This was causing a problem when creating since donation doesn't have a `subscription_id` by the moment of its creation.